### PR TITLE
Fixed docker compose kieker example

### DIFF
--- a/examples/docker/docker-compose_kieker.yaml
+++ b/examples/docker/docker-compose_kieker.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   rabbitmq:
-    image: descartesresearch/teastore-rabbitmq
+    image: descartesresearch/teastore-kieker-rabbitmq
     expose:
       - "5672"
     ports:


### PR DESCRIPTION
The image `descartesresearch/teastore-rabbitmq` does not exist anymore on docker hub.