### PR TITLE
Add helm chart

### DIFF
--- a/examples/helm/.helmignore
+++ b/examples/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/examples/helm/Chart.yaml
+++ b/examples/helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: teastore
+description: A Helm chart for TeaStore
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.4.0"

--- a/examples/helm/templates/_helpers.tpl
+++ b/examples/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "teastore.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "teastore.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "teastore.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "teastore.labels" -}}
+helm.sh/chart: {{ include "teastore.chart" . }}
+{{ include "teastore.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "teastore.selectorLabels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: teastore
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app: teastore
+version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "teastore.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "teastore.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/examples/helm/templates/auth-service.yaml
+++ b/examples/helm/templates/auth-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.auth.svc_name }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.auth.service.annotations }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+spec:
+  {{- if .Values.clientside_loadbalancer }}
+  clusterIP: None
+  {{- else }}
+  type: {{ .Values.auth.service.type }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.auth.service.port }}
+      name: http-auth
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    {{- include "teastore.auth.selectorLabels" . | nindent 4 }}

--- a/examples/helm/templates/auth-statefulset.yaml
+++ b/examples/helm/templates/auth-statefulset.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.auth.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "teastore.auth.fullname" . }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Values.auth.svc_name }}
+  {{- if not .Values.auth.autoscaling.enabled }}
+  replicas: {{ .Values.auth.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "teastore.auth.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.auth.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "teastore.auth.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.auth.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.auth.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: {{ include "teastore.auth.microservice" . }}
+          securityContext:
+            {{- toYaml .Values.auth.securityContext | nindent 12 }}
+          image: "{{ .Values.auth.image.repository }}:{{ .Values.auth.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.auth.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SERVICE_PORT
+              value: {{ .Values.auth.service.port | quote }}
+            - name: HOST_NAME
+              value: {{ template "teastore.auth.hostname" . }}
+            - name: REGISTRY_HOST
+              value: {{ template "teastore.registry.url" . }}
+            - name: REGISTRY_PORT
+              value: {{ .Values.registry.service.port | quote }}
+          resources:
+            {{- toYaml .Values.auth.resources | nindent 12 }}
+      {{- with .Values.auth.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.auth.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.auth.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/examples/helm/templates/auth.tpl
+++ b/examples/helm/templates/auth.tpl
@@ -1,0 +1,26 @@
+{{- define "teastore.auth.microservice" -}}
+auth
+{{- end }}
+
+{{- define "teastore.auth.fullname" -}}
+{{- include "teastore.fullname" . }}-{{- include "teastore.auth.microservice" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "teastore.auth.selectorLabels" -}}
+{{ include "teastore.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "teastore.auth.microservice" . }}
+app.kubernetes.io/component: authenticator
+{{- end }}
+
+{{- define "teastore.auth.hostname" -}}
+{{- if .Values.clientside_loadbalancer -}}
+$(POD_NAME).{{- .Values.auth.svc_name -}}
+{{- else if .Values.auth.url -}}
+{{- .Values.auth.url -}}
+{{- else -}}
+{{- .Values.auth.svc_name -}}
+{{- end -}}
+{{- end -}}

--- a/examples/helm/templates/db-service.yaml
+++ b/examples/helm/templates/db-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.db.svc_name }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.db.service.annotations }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+spec:
+  {{- if .Values.db.url  }}
+  type: ClusterIP
+  {{- else }}
+  clusterIP: None
+  {{- end }}
+  ports:
+    - port: {{ .Values.db.service.port }}
+      name: mysql-db
+      targetPort: 3306
+      protocol: TCP
+  selector:
+    {{- include "teastore.db.selectorLabels" . | nindent 4 }}

--- a/examples/helm/templates/db-statefulset.yaml
+++ b/examples/helm/templates/db-statefulset.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.db.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "teastore.db.fullname" . }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Values.db.svc_name }}
+  {{- if not .Values.db.autoscaling.enabled }}
+  replicas: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "teastore.db.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.db.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "teastore.db.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.db.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.db.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: {{ include "teastore.db.microservice" . }}
+          securityContext:
+            {{- toYaml .Values.db.securityContext | nindent 12 }}
+          image: "{{ .Values.db.image.repository }}:{{ .Values.db.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.db.image.pullPolicy }}
+          ports:
+            - containerPort: 3306
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.db.resources | nindent 12 }}
+      {{- with .Values.db.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.db.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.db.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/examples/helm/templates/db.tpl
+++ b/examples/helm/templates/db.tpl
@@ -1,0 +1,24 @@
+{{- define "teastore.db.microservice" -}}
+db
+{{- end }}
+
+{{- define "teastore.db.fullname" -}}
+{{- include "teastore.fullname" . }}-{{- include "teastore.db.microservice" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "teastore.db.selectorLabels" -}}
+{{ include "teastore.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "teastore.db.microservice" . }}
+app.kubernetes.io/component: database
+{{- end }}
+
+{{- define "teastore.db.url" -}}
+{{- if .Values.db.url -}}
+{{ .Values.db.url}}
+{{- else -}}
+{{ .Values.db.svc_name }}
+{{- end -}}
+{{- end -}}

--- a/examples/helm/templates/image-service.yaml
+++ b/examples/helm/templates/image-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.image.svc_name }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.image.service.annotations }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+spec:
+  {{- if .Values.clientside_loadbalancer }}
+  clusterIP: None
+  {{- else }}
+  type: {{ .Values.image.service.type }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.image.service.port }}
+      name: http-image
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    {{- include "teastore.image.selectorLabels" . | nindent 4 }}

--- a/examples/helm/templates/image-statefulset.yaml
+++ b/examples/helm/templates/image-statefulset.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.image.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "teastore.image.fullname" . }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Values.image.svc_name }}
+  {{- if not .Values.image.autoscaling.enabled }}
+  replicas: {{ .Values.image.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "teastore.image.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.image.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "teastore.image.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.image.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: {{ include "teastore.image.microservice" . }}
+          securityContext:
+            {{- toYaml .Values.image.securityContext | nindent 12 }}
+          image: "{{ .Values.image.image.repository }}:{{ .Values.image.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SERVICE_PORT
+              value: {{ .Values.image.service.port | quote }}
+            - name: HOST_NAME
+              value: {{ template "teastore.image.hostname" . }}
+            - name: REGISTRY_HOST
+              value: {{ template "teastore.registry.url" . }}
+            - name: REGISTRY_PORT
+              value: {{ .Values.registry.service.port | quote }}
+          resources:
+            {{- toYaml .Values.image.resources | nindent 12 }}
+      {{- with .Values.image.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.image.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.image.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/examples/helm/templates/image.tpl
+++ b/examples/helm/templates/image.tpl
@@ -1,0 +1,26 @@
+{{- define "teastore.image.microservice" -}}
+image
+{{- end }}
+
+{{- define "teastore.image.fullname" -}}
+{{- include "teastore.fullname" . }}-{{- include "teastore.image.microservice" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "teastore.image.selectorLabels" -}}
+{{ include "teastore.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "teastore.image.microservice" . }}
+app.kubernetes.io/component: imagegenerator
+{{- end }}
+
+{{- define "teastore.image.hostname" -}}
+{{- if .Values.clientside_loadbalancer -}}
+$(POD_NAME).{{- .Values.image.svc_name -}}
+{{- else if .Values.image.url -}}
+{{- .Values.image.url -}}
+{{- else -}}
+{{- .Values.image.svc_name -}}
+{{- end -}}
+{{- end -}}

--- a/examples/helm/templates/persistence-service.yaml
+++ b/examples/helm/templates/persistence-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.persistence.svc_name }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.persistence.service.annotations }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+spec:
+  {{- if .Values.clientside_loadbalancer }}
+  clusterIP: None
+  {{- else }}
+  type: {{ .Values.persistence.service.type }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.persistence.service.port }}
+      name: http-persistence
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    {{- include "teastore.persistence.selectorLabels" . | nindent 4 }}

--- a/examples/helm/templates/persistence-statefulset.yaml
+++ b/examples/helm/templates/persistence-statefulset.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "teastore.persistence.fullname" . }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Values.persistence.svc_name }}
+  {{- if not .Values.persistence.autoscaling.enabled }}
+  replicas: {{ .Values.persistence.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "teastore.persistence.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.persistence.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "teastore.persistence.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.persistence.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.persistence.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: {{ include "teastore.persistence.microservice" . }}
+          securityContext:
+            {{- toYaml .Values.persistence.securityContext | nindent 12 }}
+          image: "{{ .Values.persistence.image.repository }}:{{ .Values.persistence.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.persistence.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SERVICE_PORT
+              value: {{ .Values.persistence.service.port | quote }}
+            - name: HOST_NAME
+              value: {{ template "teastore.persistence.hostname" . }}
+            - name: REGISTRY_HOST
+              value: {{ template "teastore.registry.url" . }}
+            - name: REGISTRY_PORT
+              value: {{ .Values.registry.service.port | quote }}
+            - name: DB_HOST
+              value: {{ template "teastore.db.url" . }}
+            - name: DB_PORT
+              value: {{ .Values.db.service.port | quote }}
+          resources:
+            {{- toYaml .Values.persistence.resources | nindent 12 }}
+      {{- with .Values.persistence.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.persistence.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.persistence.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/examples/helm/templates/persistence.tpl
+++ b/examples/helm/templates/persistence.tpl
@@ -1,0 +1,26 @@
+{{- define "teastore.persistence.microservice" -}}
+persistence
+{{- end }}
+
+{{- define "teastore.persistence.fullname" -}}
+{{- include "teastore.fullname" . }}-{{- include "teastore.persistence.microservice" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "teastore.persistence.selectorLabels" -}}
+{{ include "teastore.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "teastore.persistence.microservice" . }}
+app.kubernetes.io/component: cache
+{{- end }}
+
+{{- define "teastore.persistence.hostname" -}}
+{{- if .Values.clientside_loadbalancer -}}
+$(POD_NAME).{{- .Values.persistence.svc_name -}}
+{{- else if .Values.persistence.url -}}
+{{- .Values.persistence.url -}}
+{{- else -}}
+{{- .Values.persistence.svc_name -}}
+{{- end -}}
+{{- end -}}

--- a/examples/helm/templates/recommender-service.yaml
+++ b/examples/helm/templates/recommender-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.recommender.svc_name }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.recommender.service.annotations }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+spec:
+  {{- if .Values.clientside_loadbalancer }}
+  clusterIP: None
+  {{- else }}
+  type: {{ .Values.recommender.service.type }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.recommender.service.port }}
+      name: http-recommender
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    {{- include "teastore.recommender.selectorLabels" . | nindent 4 }}

--- a/examples/helm/templates/recommender-statefulset.yaml
+++ b/examples/helm/templates/recommender-statefulset.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.recommender.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "teastore.recommender.fullname" . }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Values.recommender.svc_name }}
+  {{- if not .Values.recommender.autoscaling.enabled }}
+  replicas: {{ .Values.recommender.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "teastore.recommender.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.recommender.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "teastore.recommender.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.recommender.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.recommender.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: {{ include "teastore.recommender.microservice" . }}
+          securityContext:
+            {{- toYaml .Values.recommender.securityContext | nindent 12 }}
+          image: "{{ .Values.recommender.image.repository }}:{{ .Values.recommender.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.recommender.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SERVICE_PORT
+              value: {{ .Values.recommender.service.port | quote }}
+            - name: HOST_NAME
+              value: {{ template "teastore.recommender.hostname" . }}
+            - name: REGISTRY_HOST
+              value: {{ template "teastore.registry.url" . }}
+            - name: REGISTRY_PORT
+              value: {{ .Values.registry.service.port | quote }}
+          resources:
+            {{- toYaml .Values.recommender.resources | nindent 12 }}
+      {{- with .Values.recommender.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.recommender.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.recommender.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/examples/helm/templates/recommender.tpl
+++ b/examples/helm/templates/recommender.tpl
@@ -1,0 +1,26 @@
+{{- define "teastore.recommender.microservice" -}}
+recommender
+{{- end }}
+
+{{- define "teastore.recommender.fullname" -}}
+{{- include "teastore.fullname" . }}-{{- include "teastore.recommender.microservice" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "teastore.recommender.selectorLabels" -}}
+{{ include "teastore.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "teastore.recommender.microservice" . }}
+app.kubernetes.io/component: recommender
+{{- end }}
+
+{{- define "teastore.recommender.hostname" -}}
+{{- if .Values.clientside_loadbalancer -}}
+$(POD_NAME).{{- .Values.recommender.svc_name -}}
+{{- else if .Values.recommender.url -}}
+{{- .Values.recommender.url -}}
+{{- else -}}
+{{- .Values.recommender.svc_name -}}
+{{- end -}}
+{{- end -}}

--- a/examples/helm/templates/registry-service.yaml
+++ b/examples/helm/templates/registry-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.registry.svc_name }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.registry.service.annotations }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+spec:
+  {{- if .Values.registry.url  }}
+  type: ClusterIP
+  {{- else }}
+  clusterIP: None
+  {{- end }}
+  ports:
+    - port: {{ .Values.registry.service.port }}
+      name: http-registry
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    {{- include "teastore.registry.selectorLabels" . | nindent 4 }}

--- a/examples/helm/templates/registry-statefulset.yaml
+++ b/examples/helm/templates/registry-statefulset.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.registry.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "teastore.registry.fullname" . }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Values.registry.svc_name }}
+  {{- if not .Values.registry.autoscaling.enabled }}
+  replicas: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "teastore.registry.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.registry.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "teastore.registry.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.registry.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.registry.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: {{ include "teastore.registry.microservice" . }}
+          securityContext:
+            {{- toYaml .Values.registry.securityContext | nindent 12 }}
+          image: "{{ .Values.registry.image.repository }}:{{ .Values.registry.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.registry.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.registry.resources | nindent 12 }}
+      {{- with .Values.registry.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.registry.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.registry.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/examples/helm/templates/registry.tpl
+++ b/examples/helm/templates/registry.tpl
@@ -1,0 +1,24 @@
+{{- define "teastore.registry.microservice" -}}
+registry
+{{- end }}
+
+{{- define "teastore.registry.fullname" -}}
+{{- include "teastore.fullname" . }}-{{- include "teastore.registry.microservice" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "teastore.registry.selectorLabels" -}}
+{{ include "teastore.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "teastore.registry.microservice" . }}
+app.kubernetes.io/component: registry
+{{- end }}
+
+{{- define "teastore.registry.url" -}}
+{{- if .Values.registry.url -}}
+{{ .Values.registry.url}}
+{{- else -}}
+{{ .Values.registry.svc_name }}
+{{- end -}}
+{{- end -}}

--- a/examples/helm/templates/webui-service.yaml
+++ b/examples/helm/templates/webui-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.webui.svc_name }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.webui.service.annotations }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+spec:
+  {{- if and (.Values.clientside_loadbalancer) (eq ( .Values.webui.replicaCount | int ) 1) }}
+  clusterIP: None
+  {{- else }}
+  type: {{ .Values.webui.service.type }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.webui.service.port }}
+      name: http-webui
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    {{- include "teastore.webui.selectorLabels" . | nindent 4 }}

--- a/examples/helm/templates/webui-statefulset.yaml
+++ b/examples/helm/templates/webui-statefulset.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.webui.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "teastore.webui.fullname" . }}
+  labels:
+    {{- include "teastore.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Values.webui.svc_name }}
+  {{- if not .Values.webui.autoscaling.enabled }}
+  replicas: {{ .Values.webui.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "teastore.webui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.webui.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "teastore.webui.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.webui.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.webui.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: {{ include "teastore.webui.microservice" . }}
+          securityContext:
+            {{- toYaml .Values.webui.securityContext | nindent 12 }}
+          image: "{{ .Values.webui.image.repository }}:{{ .Values.webui.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.webui.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SERVICE_PORT
+              value: {{ .Values.webui.service.port | quote }}
+            - name: HOST_NAME
+              value: {{ template "teastore.webui.hostname" . }}
+            - name: REGISTRY_HOST
+              value: {{ template "teastore.registry.url" . }}
+            - name: REGISTRY_PORT
+              value: {{ .Values.registry.service.port | quote }}
+          resources:
+            {{- toYaml .Values.webui.resources | nindent 12 }}
+      {{- with .Values.webui.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webui.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webui.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/examples/helm/templates/webui.tpl
+++ b/examples/helm/templates/webui.tpl
@@ -1,0 +1,26 @@
+{{- define "teastore.webui.microservice" -}}
+webui
+{{- end }}
+
+{{- define "teastore.webui.fullname" -}}
+{{- include "teastore.fullname" . }}-{{- include "teastore.webui.microservice" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "teastore.webui.selectorLabels" -}}
+{{ include "teastore.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "teastore.webui.microservice" . }}
+app.kubernetes.io/component: webserver
+{{- end }}
+
+{{- define "teastore.webui.hostname" -}}
+{{- if .Values.clientside_loadbalancer -}}
+$(POD_NAME).{{- .Values.webui.svc_name -}}
+{{- else if .Values.webui.url -}}
+{{- .Values.webui.url -}}
+{{- else -}}
+{{- .Values.webui.svc_name -}}
+{{- end -}}
+{{- end -}}

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -1,0 +1,186 @@
+clientside_loadbalancer: false # Deploys as Statefulset which enables communication to every instance individually. A kubernetes service is used otherwise
+webui:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: descartesresearch/teastore-webui
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  imagePullSecrets: []
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  service:
+    type: ClusterIP
+    port: 80
+    annotations: {}
+  resources: {}
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  svc_name: teastore-webui
+registry:
+  enabled: true
+  image:
+    repository: descartesresearch/teastore-registry
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  imagePullSecrets: []
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  service:
+    port: 8080
+    annotations: {}
+  resources: {}
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  svc_name: teastore-registry
+db:
+  enabled: true
+  image:
+    repository: descartesresearch/teastore-db
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  imagePullSecrets: []
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  service:
+    port: 3306
+    annotations: {}
+  resources: {}
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  svc_name: teastore-db
+auth:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: descartesresearch/teastore-auth
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  imagePullSecrets: []
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  resources: {}
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  svc_name: teastore-auth
+image:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: descartesresearch/teastore-image
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  imagePullSecrets: []
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  resources: {}
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  svc_name: teastore-image
+recommender:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: descartesresearch/teastore-recommender
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  imagePullSecrets: []
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  resources: {}
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  svc_name: teastore-recommender
+persistence:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: descartesresearch/teastore-persistence
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  imagePullSecrets: []
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  resources: {}
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  svc_name: teastore-persistence


### PR DESCRIPTION
This PR adds a helm chart which can be used to deploy TeaStore. With the `clientside_loadbalancer` variable you can change between the deployment as a Statefulset that utilizes the TeasStore Loadbalancer and a regular Deployment that uses Kubernetes Services.