### PR TITLE
Fix parsing error

### DIFF
--- a/examples/kubernetes/teastore-clusterip.yaml
+++ b/examples/kubernetes/teastore-clusterip.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
When trying to deploy TeaStore using Kubernetes ClusterIP feature, using the following command (as described in https://github.com/DescartesResearch/TeaStore/blob/master/GET_STARTED.md#13-run-the-teastore-on-a-kubernetes-cluster)

```
$ kubectl create -f https://github.com/DescartesResearch/TeaStore/blob/master/examples/kubernetes/teastore-clusterip.yaml
```
We get the following error:

```
error: error parsing https://github.com/DescartesResearch/TeaStore/blob/master/examples/kubernetes/teastore-clusterip.yaml: error converting YAML to JSON: yaml: line 27: mapping values are not allowed in this context
```
Fixed using yamllint