### PR TITLE
Added app=teastore to metadata of deployments

### DIFF
--- a/examples/kubernetes/teastore-clusterip.yaml
+++ b/examples/kubernetes/teastore-clusterip.yaml
@@ -3,6 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-db
+  labels:
+    app: teastore
+    run: teastore-db
 spec:
   selector:
     matchLabels:
@@ -38,6 +41,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-registry
+  labels:
+    app: teastore
+    run: teastore-registry
 spec:
   selector:
     matchLabels:
@@ -73,6 +79,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-persistence
+  labels:
+    app: teastore
+    run: teastore-persistence
 spec:
   selector:
     matchLabels:
@@ -117,6 +126,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-auth
+  labels:
+    app: teastore
+    run: teastore-auth
 spec:
   selector:
     matchLabels:
@@ -157,6 +169,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-image
+  labels:
+    app: teastore
+    run: teastore-image
 spec:
   selector:
     matchLabels:
@@ -197,6 +212,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-recommender
+  labels:
+    app: teastore
+    run: teastore-recommender
 spec:
   selector:
     matchLabels:
@@ -237,6 +255,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-webui
+  labels:
+    app: teastore
+    run: teastore-webui
 spec:
   selector:
     matchLabels:

--- a/examples/kubernetes/teastore-rabbitmq.yaml
+++ b/examples/kubernetes/teastore-rabbitmq.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-kieker-rabbitmq
+  labels:
+    app: teastore
+    run: teastore-kieker-rabbitmq
 spec:
   selector:	
     matchLabels:	

--- a/examples/kubernetes/teastore-ribbon-kieker.yaml
+++ b/examples/kubernetes/teastore-ribbon-kieker.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-db
+  labels:
+    app: teastore
+    run: teastore-db
 spec:
   selector:
     matchLabels:
@@ -37,6 +40,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-registry
+  labels:
+    app: teastore
+    run: teastore-registry
 spec:
   selector:
     matchLabels:
@@ -75,6 +81,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-persistence
+  labels:
+    app: teastore
+    run: teastore-persistence
 spec:
   selector:
     matchLabels:
@@ -107,6 +116,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-auth
+  labels:
+    app: teastore
+    run: teastore-auth
 spec:
   selector:
     matchLabels:
@@ -135,6 +147,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-image
+  labels:
+    app: teastore
+    run: teastore-image
 spec:
   selector:
     matchLabels:
@@ -163,6 +178,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-recommender
+  labels:
+    app: teastore
+    run: teastore-recommender
 spec:
   selector:
     matchLabels:
@@ -191,6 +209,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-webui
+  labels:
+    app: teastore
+    run: teastore-webui
 spec:
   selector:
     matchLabels:

--- a/examples/kubernetes/teastore-ribbon.yaml
+++ b/examples/kubernetes/teastore-ribbon.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-db
+  labels:
+    app: teastore
+    run: teastore-db
 spec:
   selector:
     matchLabels:
@@ -37,6 +40,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-registry
+  labels:
+    app: teastore
+    run: teastore-registry
 spec:
   selector:
     matchLabels:
@@ -75,6 +81,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-persistence
+  labels:
+    app: teastore
+    run: teastore-persistence
 spec:
   selector:
     matchLabels:
@@ -105,6 +114,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-auth
+  labels:
+    app: teastore
+    run: teastore-auth
 spec:
   selector:
     matchLabels:
@@ -131,6 +143,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-image
+  labels:
+    app: teastore
+    run: teastore-image
 spec:
   selector:
     matchLabels:
@@ -157,6 +172,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-recommender
+  labels:
+    app: teastore
+    run: teastore-recommender
 spec:
   selector:
     matchLabels:
@@ -183,6 +201,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: teastore-webui
+  labels:
+    app: teastore
+    run: teastore-webui
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
In the new Kubernetes YAML files, I've added "app=teastore" labels to the metadata of deployments. So that, deployments are returned when "-l app=teastore" is applied.

Please refer to https://github.com/DescartesResearch/TeaStore/issues/251 