### PR TITLE
Only deploy if flag $DEPLOY is set

### DIFF
--- a/tools/build_docker.sh
+++ b/tools/build_docker.sh
@@ -15,17 +15,32 @@ while getopts 'pr:' flag; do
   esac
 done
 
-docker run -it --rm --privileged tonistiigi/binfmt --install all
-docker buildx create --use --name mybuilder
-docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-db" ../utilities/tools.descartes.teastore.database/ --push
-docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-kieker-rabbitmq" ../utilities/tools.descartes.teastore.kieker.rabbitmq/ --push
-docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-base" ../utilities/tools.descartes.teastore.dockerbase/ --push
-perl -i -pe's|.*FROM descartesresearch/|FROM '"${registry}"'|g' ../services/tools.descartes.teastore.*/Dockerfile
-docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-registry" ../services/tools.descartes.teastore.registry/ --push
-docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-persistence" ../services/tools.descartes.teastore.persistence/ --push
-docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-image" ../services/tools.descartes.teastore.image/ --push
-docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-webui" ../services/tools.descartes.teastore.webui/ --push
-docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-auth" ../services/tools.descartes.teastore.auth/ --push
-docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-recommender" ../services/tools.descartes.teastore.recommender/ --push
-perl -i -pe's|.*FROM '"${registry}"'|FROM descartesresearch/|g' ../services/tools.descartes.teastore.*/Dockerfile
-docker buildx rm mybuilder
+if [ $DEPLOY == 1 ]
+then
+	docker run -it --rm --privileged tonistiigi/binfmt --install all
+	docker buildx create --use --name mybuilder
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-db" ../utilities/tools.descartes.teastore.database/ --push
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-kieker-rabbitmq" ../utilities/tools.descartes.teastore.kieker.rabbitmq/ --push
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-base" ../utilities/tools.descartes.teastore.dockerbase/ --push
+	perl -i -pe's|.*FROM descartesresearch/|FROM '"${registry}"'|g' ../services/tools.descartes.teastore.*/Dockerfile
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-registry" ../services/tools.descartes.teastore.registry/ --push
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-persistence" ../services/tools.descartes.teastore.persistence/ --push
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-image" ../services/tools.descartes.teastore.image/ --push
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-webui" ../services/tools.descartes.teastore.webui/ --push
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-auth" ../services/tools.descartes.teastore.auth/ --push
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t "${registry}teastore-recommender" ../services/tools.descartes.teastore.recommender/ --push
+	perl -i -pe's|.*FROM '"${registry}"'|FROM descartesresearch/|g' ../services/tools.descartes.teastore.*/Dockerfile
+	docker buildx rm mybuilder
+else
+	registry='descartesresearch/'
+	docker buildx build -t "${registry}teastore-db" ../utilities/tools.descartes.teastore.database/ --load
+	docker buildx build -t "${registry}teastore-kieker-rabbitmq" ../utilities/tools.descartes.teastore.kieker.rabbitmq/ --load
+	docker buildx build -t "${registry}teastore-base" ../utilities/tools.descartes.teastore.dockerbase/ --load
+	docker buildx build -t "${registry}teastore-registry" ../services/tools.descartes.teastore.registry/ --load
+	docker buildx build -t "${registry}teastore-persistence" ../services/tools.descartes.teastore.persistence/ --load
+	docker buildx build -t "${registry}teastore-image" ../services/tools.descartes.teastore.image/ --load
+	docker buildx build -t "${registry}teastore-webui" ../services/tools.descartes.teastore.webui/ --load
+	docker buildx build -t "${registry}teastore-auth" ../services/tools.descartes.teastore.auth/ --load
+	docker buildx build -t "${registry}teastore-recommender" ../services/tools.descartes.teastore.recommender/ --load
+fi
+


### PR DESCRIPTION
When trying to build the TeaStore images locally, by running

```
mvn clean package
cd tools/
./build_docker.sh
```

This results in errors like

`ERROR: failed to solve: teastore-base:latest: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
mybuilder removed`

for every image that depends on `teastore-base`.

To be able to build the TeaStore locally for testing purposes, I recommend introducing a flag `$DEPLOY`, and to only execute the `push` and the multi platform built if this flag is set.