### PR TITLE
Update to Kieker 1.15.4

### DIFF
--- a/interfaces/tools.descartes.teastore.entities/pom.xml
+++ b/interfaces/tools.descartes.teastore.entities/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>net.kieker-monitoring</groupId>
 			<artifactId>kieker</artifactId>
-			<version>1.15</version>
+			<version>1.15.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/utilities/tools.descartes.teastore.kieker.probes/pom.xml
+++ b/utilities/tools.descartes.teastore.kieker.probes/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>net.kieker-monitoring</groupId>
 			<artifactId>kieker</artifactId>
-			<version>1.15</version>
+			<version>1.15.4</version>
 			<classifier>aspectj</classifier>
 		</dependency>
 

--- a/utilities/tools.descartes.teastore.kieker.rabbitmq/pom.xml
+++ b/utilities/tools.descartes.teastore.kieker.rabbitmq/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>net.kieker-monitoring</groupId>
 			<artifactId>kieker</artifactId>
-			<version>1.14</version>
+			<version>1.15.4</version>
 		</dependency>
 		<dependency>
 			<groupId>log4j</groupId>

--- a/utilities/tools.descartes.teastore.registryclient/pom.xml
+++ b/utilities/tools.descartes.teastore.registryclient/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>net.kieker-monitoring</groupId>
 			<artifactId>kieker</artifactId>
-			<version>1.15</version>
+			<version>1.15.4</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jaegertracing</groupId>


### PR DESCRIPTION
Kieker 1.15 is outdated, and should be updated to 1.15.4 (and, after the release that will happen soon, to 2.0.0). 