### PR TITLE
Update to tomcat:10.0.27-jdk11-temurin

### DIFF
--- a/utilities/tools.descartes.teastore.dockerbase/Dockerfile
+++ b/utilities/tools.descartes.teastore.dockerbase/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:10.0.7-jdk11
+FROM tomcat:10.0.27-jdk11-temurin
 MAINTAINER Chair of Software Engineering <se2-it@informatik.uni-wuerzburg.de>
 
 RUN rm /usr/local/tomcat/lib/websocket-api.jar
@@ -41,7 +41,7 @@ RUN chmod +x /usr/local/tomcat/bin/start.sh
 
 RUN mkdir -p /kieker/logs
 # Import self-signed certificate for HTTPS teastore into keystore. NOTE: to adapt certificate hostnames, configure and run ssl/generate_cert.sh and rebuild the container!
-RUN keytool -import -noprompt -trustcacerts -alias teastoressl -file /usr/local/tomcat/ssl/cert.pem -keystore "/usr/local/openjdk-11/lib/security/cacerts" -storepass changeit
+RUN keytool -import -noprompt -trustcacerts -alias teastoressl -file /usr/local/tomcat/ssl/cert.pem -keystore "/opt/java/openjdk/lib/security/cacerts" -storepass changeit
 
 COPY kieker.monitoring.properties 							/kieker/config/kieker.monitoring.properties
 COPY aop.xml 												            /usr/local/tomcat/lib/aop.xml


### PR DESCRIPTION
Tomcat 10.0.7 is outdated, so it should be updated. This requires using temurin instead of OpenJDK, and changing the path.

Updating to 10.1.29 would be better - unfortunately, if I do so, the services stay at the following state (without any error messages in the logs):

![grafik](https://github.com/user-attachments/assets/8ae11bdc-a874-48c4-b692-e48d49d112f5)

So this update could be the first step towards the update to 10.1.29. 