### PR TITLE
Update to jersey 3.1.8

### DIFF
--- a/services/tools.descartes.teastore.registry/pom.xml
+++ b/services/tools.descartes.teastore.registry/pom.xml
@@ -66,22 +66,22 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet</artifactId>
-			<version>3.0.2</version>
+			<version>3.1.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
-			<version>3.0.2</version>
+			<version>3.1.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-server</artifactId>
-			<version>3.0.2</version>
+			<version>3.1.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
-			<version>3.0.2</version>
+			<version>3.1.8</version>
 		</dependency>
 
 		<!-- Dependencies only needed for compilation -->

--- a/utilities/tools.descartes.teastore.registryclient/pom.xml
+++ b/utilities/tools.descartes.teastore.registryclient/pom.xml
@@ -29,27 +29,27 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet</artifactId>
-			<version>3.0.2</version>
+			<version>3.1.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
-			<version>3.0.2</version>
+			<version>3.1.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-server</artifactId>
-			<version>3.0.2</version>
+			<version>3.1.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.connectors</groupId>
 			<artifactId>jersey-grizzly-connector</artifactId>
-			<version>3.0.2</version>
+			<version>3.1.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
-			<version>3.0.2</version>
+			<version>3.1.8</version>
 		</dependency>
 		<!-- WebApp Dependencies -->
 		<!-- jackson, slf4j, and rx must be included before ribbon to avoid version
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
-			<version>3.0.2</version>
+			<version>3.1.8</version>
 		</dependency>
 		<dependency>
 			<!-- Logging framework also used by ribbon -->


### PR DESCRIPTION
The jersey version in the dependencies is slightly outdated and should be updated to 3.1.8. According to my tests, everything is still running after the update.