### PR TITLE
Fix docker memory configurator - adapt for cgroupsv2

### DIFF
--- a/utilities/tools.descartes.teastore.dockerbase/start.sh
+++ b/utilities/tools.descartes.teastore.dockerbase/start.sh
@@ -43,5 +43,5 @@ fi
 
 touch /usr/local/tomcat/bin/setenv.sh
 chmod +x /usr/local/tomcat/bin/setenv.sh
-echo 'export JAVA_OPTS="-javaagent:/kieker/agent/agent.jar --add-opens=java.base/java.lang=ALL-UNNAMED -Dkieker.monitoring.configuration=/kieker/config/kieker.monitoring.properties -Daj.weaving.verbose=false -Dorg.aspectj.weaver.loadtime.configuration=aop.xml -Dkieker.monitoring.skipDefaultAOPConfiguration=true -Daj.weaving.loadersToSkip=java.net.URLClassLoader -Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true"' > /usr/local/tomcat/bin/setenv.sh
+echo 'export JAVA_OPTS="-javaagent:/kieker/agent/agent.jar --add-opens=java.base/java.lang=ALL-UNNAMED -Dkieker.monitoring.configuration=/kieker/config/kieker.monitoring.properties -Daj.weaving.verbose=false -Dorg.aspectj.weaver.loadtime.configuration=aop.xml -Dkieker.monitoring.skipDefaultAOPConfiguration=true -Daj.weaving.loadersToSkip=java.net.URLClassLoader -Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true"' >> /usr/local/tomcat/bin/setenv.sh
 

--- a/utilities/tools.descartes.teastore.dockermemoryconfigurator/src/main/java/tools/descartes/teastore/dockermemoryconfigurator/Configurator.java
+++ b/utilities/tools.descartes.teastore.dockermemoryconfigurator/src/main/java/tools/descartes/teastore/dockermemoryconfigurator/Configurator.java
@@ -43,6 +43,8 @@ public final class Configurator {
       System.out.println("Setting heap space to " + heapkb + " KiB");
       writeSetEnvFile(heapkb);
 
+    } else {
+      System.out.println("Unable to set heap space, cgroupkb: " + cgroupkb + " totalkb: " + totalkb);
     }
   }
 
@@ -99,8 +101,19 @@ public final class Configurator {
    * @return 0 on error.
    */
   private static long readCGroupMemoryInKB() {
-    File cgroupbytes = new File("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+    File cgroupbytes1 = new File("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+    File cgroupbytes2 = new File("/sys/fs/cgroup/memory.max");
+    File cgroupbytes = null;
+    System.out.println("cgroup memory max file " + cgroupbytes1.getAbsolutePath() + " exists: " + cgroupbytes1.exists());
+    if (cgroupbytes1.exists()) {
+    	cgroupbytes = cgroupbytes1;
+    }
+    System.out.println("cgroup memory max file " + cgroupbytes2.getAbsolutePath() + " exists: " + cgroupbytes2.exists());
+    if (cgroupbytes2.exists()) {
+    	cgroupbytes = cgroupbytes2;
+    }
     if (!cgroupbytes.exists()) {
+      System.out.println("cgroup memory limit files not existing");
       return 0;
     }
 


### PR DESCRIPTION
The file `/sys/fs/cgroup/memory/memory.limit_in_bytes` is not present in most modern linux environments, since it was renamed to `/sys/fs/cgroup/memory.max` with cgroupsv2. To keep the TeaStore runnable, it should be possible to use both. If the memory configuration doesn't take place, load tests often lead to very hard-to-trace memory problems.

Additionally, the configuration in `setenv.sh` should be added using `>>`, so the thing written by the memory configurator stays in the file.