### PR TITLE
Cleanup dependencies

### DIFF
--- a/services/tools.descartes.teastore.image/pom.xml
+++ b/services/tools.descartes.teastore.image/pom.xml
@@ -27,16 +27,6 @@
 			<version>${teastoreversion}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>jakarta.activation</groupId>
 			<artifactId>jakarta.activation-api</artifactId>
 			<version>2.0.1</version>

--- a/services/tools.descartes.teastore.persistence/pom.xml
+++ b/services/tools.descartes.teastore.persistence/pom.xml
@@ -55,13 +55,14 @@
 			<artifactId>jbcrypt</artifactId>
 			<version>0.4</version>
 		</dependency>
+		
+		<!-- Test Dependencies -->
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 			<version>2.7.1</version>
+			<scope>test</scope>
 		</dependency>
-
-		<!-- Test Dependencies -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>


### PR DESCRIPTION
slf4j is in the image dependencies, but not necessary, since its already in the `registryclient` and transitively used from there anyhow.

Additionally, as far as I see, the hsqldb dependency is not required at runtime, only for testing, since at runtime, a MariaDB container is used. 