### PR TITLE
Update containers to 10.1.43-jre21-temurin

### DIFF
--- a/utilities/tools.descartes.teastore.dockerbase/Dockerfile
+++ b/utilities/tools.descartes.teastore.dockerbase/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:10.0.27-jdk11-temurin
+FROM tomcat:10.1.43-jre21-temurin
 MAINTAINER Chair of Software Engineering <se2-it@informatik.uni-wuerzburg.de>
 
 RUN rm /usr/local/tomcat/lib/websocket-api.jar


### PR DESCRIPTION
The old 10.0.27 tomcat is outdated (from 2022) and uses an outdated Java version. With this PR, both get updated.